### PR TITLE
Feat: Export mASAPP responses and compatibility with the traditional mASAPP response

### DIFF
--- a/masappcli/__main__.py
+++ b/masappcli/__main__.py
@@ -37,6 +37,8 @@ def cli(parser):
                         action='store_true')
     parser.add_argument('-w', '--workgroup', type=str, metavar="workgroup name",
                         help="the name of the workgroup you want to analyse in")
+    parser.add_argument('--export_summary', help='export the scan summary from mASAPP in a json file', metavar="*.json")
+    parser.add_argument('--export_result', help='export the scan result from mASAPP in a json file', metavar="*.json")
 
     args = parser.parse_args()
 
@@ -82,6 +84,18 @@ def cli(parser):
     if masapp_key is not None and masapp_secret is not None:
         workgroup = getattr(args, 'workgroup', None)
 
+        if args.export_summary and args.export_result:
+            if args.export_summary == args.export_result:
+                raise ValueError("[X] Export files can not be named with the same name")
+
+        if args.export_summary:
+            if args.export_summary in os.listdir('.'):
+                raise ValueError("[X] Export summary file already exists")
+
+        if args.export_result:
+            if args.export_result in os.listdir('.'):
+                raise ValueError("[X] Export result file already exists")
+
         if args.riskscore and args.standard:
             raise ValueError("[X] Riskscore and standard execution can not being thrown simultaneously")
 
@@ -93,11 +107,17 @@ def cli(parser):
                     user.riskscoring_execution(maximum_riskscoring=args.riskscore, app_path=args.app,
                                                package_name_origin=args.packageNameOrigin,
                                                workgroup=workgroup,
-                                               detail=args.detailed)
+                                               detail=args.detailed,
+                                               export_summary=args.export_summary,
+                                               export_result=args.export_result
+                                               )
                 else:
                     user.riskscoring_execution(maximum_riskscoring=args.riskscore, app_path=args.app,
                                                workgroup=workgroup,
-                                               detail=args.detailed)
+                                               detail=args.detailed,
+                                               export_summary=args.export_summary,
+                                               export_result=args.export_result
+                                               )
             else:
                 raise ValueError("[X] No path to the app added")
 
@@ -114,12 +134,18 @@ def cli(parser):
                                 user.standard_execution(scan_maximum_values=checked_json, app_path=args.app,
                                                         package_name_origin=args.packageNameOrigin,
                                                         workgroup=workgroup,
-                                                        detail=args.detailed)
+                                                        detail=args.detailed,
+                                                        export_summary=args.export_summary,
+                                                        export_result=args.export_result
+                                                        )
 
                             else:
                                 user.standard_execution(scan_maximum_values=checked_json, app_path=args.app,
                                                         workgroup=workgroup,
-                                                        detail=args.detailed)
+                                                        detail=args.detailed,
+                                                        export_summary=args.export_summary,
+                                                        export_result=args.export_result
+                                                        )
                     else:
                         print(
                             u"""


### PR DESCRIPTION
### :bust_in_silhouette: Who
:+1: 

### :point_up: Goal(s)
* masappcli debe exportar en un JSON que se generará en el directorio actual el resultado de /scanResults (en store_scan_result) y/o el de /scanSummary (en store_scan_summary_from_scan_id)

* masappcli será compatible también con la versión actual de mASAPP para así no bloquear el lanzamiento de esta nueva versión de masappcli con la nueva versión de mASAPP

### :memo: Resolved issues
*  [US](https://trello.com/c/MIOIANgm/136-store-in-a-json-all-the-masapps-output)
* [Guardar en un json todo el output de mASAPP: Creación](https://trello.com/c/oqbwHLxQ/135-guardar-en-un-json-todo-el-output-de-masapp-creaci%C3%B3n)


### :ballot_box_with_check: Checklist
*  [ ] I've verified that unitary tests has been developed if it applies 
*  [x] I've verified in [Travis](https://travis-ci.org/alopezna5/mASAPP_CI/builds) that all tests has been successfully executed for the last commit of this PR.
*  [x] I've verified in [Codacy](https://app.codacy.com/manual/alopezna5/mASAPP_CI/dashboard) that there are no relevant new issues in the contained commits of this PR.
*  [ ] If this PR performs a new version I've verified that the new release is correctly uploaded to GitHub.
*  [ ] If this PR performs a new version I've verified that the new release is correctly uploaded to PyPI.


